### PR TITLE
Enforce time.Local = time.UTC in all binary entrypoints

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -3,9 +3,14 @@ package main
 import (
 	"runtime/debug"
 	"strings"
+	"time"
 
 	"github.com/duneanalytics/cli/cli"
 )
+
+func init() {
+	time.Local = time.UTC
+}
 
 // Set by GoReleaser or Makefile via ldflags.
 var (

--- a/makefile
+++ b/makefile
@@ -37,7 +37,7 @@ lint: bin/golangci-lint lint-timezone
 # time.Now() always returns UTC.
 lint-timezone:
 	@fail=0; \
-	for f in $$(find . -name main.go -path '*/cmd/*/main.go'); do \
+	for f in $$(find . -name main.go -path '*/cmd/*'); do \
 		if ! grep -q 'time\.Local = time\.UTC' "$$f"; then \
 			echo "ERROR: $$f missing 'time.Local = time.UTC' in init()"; \
 			fail=1; \

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-.PHONY: all setup build run lint test
+.PHONY: all setup build run lint lint-timezone test
 
 VERSION        ?= $(shell git describe --tags --always --dirty 2>/dev/null | sed 's/^v//')
 COMMIT         ?= $(shell git rev-parse --short=12 HEAD 2>/dev/null || echo "unknown")
@@ -27,11 +27,23 @@ bin:
 bin/golangci-lint: bin
 	GOBIN=$(PWD)/bin go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8
 
-lint: bin/golangci-lint
+lint: bin/golangci-lint lint-timezone
 	go fmt ./...
 	go vet ./...
 	bin/golangci-lint -c .golangci.yml run ./...
 	go mod tidy
+
+# All binary entrypoints must set time.Local = time.UTC in init() to ensure
+# time.Now() always returns UTC.
+lint-timezone:
+	@fail=0; \
+	for f in $$(find . -name main.go -path '*/cmd/*/main.go'); do \
+		if ! grep -q 'time\.Local = time\.UTC' "$$f"; then \
+			echo "ERROR: $$f missing 'time.Local = time.UTC' in init()"; \
+			fail=1; \
+		fi; \
+	done; \
+	if [ "$$fail" -eq 1 ]; then exit 1; fi
 
 test:
 	go test -timeout=10s -race -cover -bench=. -benchmem ./...


### PR DESCRIPTION
## Summary
- Adds `time.Local = time.UTC` in `init()` to `cmd/main.go` — was missing, meaning `time.Now()` could return non-UTC timestamps depending on the host timezone
- Adds a `lint-timezone` Makefile target that auto-discovers all `cmd/*/main.go` files and verifies they contain `time.Local = time.UTC`, failing with a clear error if any are missing
- Runs as part of `make lint`, so it's caught both locally and in CI

## Context
Cross-repo follow-up to duneanalytics/core#5718 and duneanalytics/core#5729. The convention across Dune Go services is to set `time.Local = time.UTC` in `init()` at each binary entrypoint so `time.Now()` always returns UTC. This lint ensures new entrypoints don't forget it.