### PR TITLE
Add sim command foundation

### DIFF
--- a/authconfig/authconfig.go
+++ b/authconfig/authconfig.go
@@ -13,6 +13,7 @@ import (
 // Config holds the persisted CLI configuration.
 type Config struct {
 	APIKey    string `yaml:"api_key"`
+	SimAPIKey string `yaml:"sim_api_key,omitempty"`
 	Telemetry *bool  `yaml:"telemetry,omitempty"`
 }
 

--- a/cli/root.go
+++ b/cli/root.go
@@ -20,6 +20,7 @@ import (
 	"github.com/duneanalytics/cli/cmd/docs"
 	"github.com/duneanalytics/cli/cmd/execution"
 	"github.com/duneanalytics/cli/cmd/query"
+	"github.com/duneanalytics/cli/cmd/sim"
 	"github.com/duneanalytics/cli/cmd/usage"
 	"github.com/duneanalytics/cli/cmdutil"
 	"github.com/duneanalytics/cli/tracking"
@@ -106,6 +107,7 @@ func init() {
 	rootCmd.AddCommand(query.NewQueryCmd())
 	rootCmd.AddCommand(execution.NewExecutionCmd())
 	rootCmd.AddCommand(usage.NewUsageCmd())
+	rootCmd.AddCommand(sim.NewSimCmd())
 }
 
 // Execute runs the root command via Fang.

--- a/cmd/sim/client.go
+++ b/cmd/sim/client.go
@@ -1,0 +1,110 @@
+package sim
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+const defaultBaseURL = "https://api.sim.dune.com"
+
+// SimClient is a lightweight HTTP client for the Sim API.
+type SimClient struct {
+	baseURL    string
+	apiKey     string
+	httpClient *http.Client
+}
+
+// NewSimClient creates a new Sim API client with the given API key.
+func NewSimClient(apiKey string) *SimClient {
+	return &SimClient{
+		baseURL: defaultBaseURL,
+		apiKey:  apiKey,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
+// Get performs a GET request to the Sim API and returns the raw JSON response body.
+// The path should include the leading slash (e.g. "/v1/evm/supported-chains").
+// Query parameters are appended from params.
+func (c *SimClient) Get(ctx context.Context, path string, params url.Values) ([]byte, error) {
+	u, err := url.Parse(c.baseURL + path)
+	if err != nil {
+		return nil, fmt.Errorf("invalid URL: %w", err)
+	}
+	if params != nil {
+		u.RawQuery = params.Encode()
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("X-Sim-Api-Key", c.apiKey)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response: %w", err)
+	}
+
+	if resp.StatusCode >= 400 {
+		return nil, httpError(resp.StatusCode, body)
+	}
+
+	return body, nil
+}
+
+// httpError returns a user-friendly error for HTTP error status codes.
+func httpError(status int, body []byte) error {
+	// Try to extract a message from the JSON error response.
+	var errResp struct {
+		Error   string `json:"error"`
+		Message string `json:"message"`
+	}
+	msg := ""
+	if json.Unmarshal(body, &errResp) == nil {
+		if errResp.Error != "" {
+			msg = errResp.Error
+		} else if errResp.Message != "" {
+			msg = errResp.Message
+		}
+	}
+
+	switch status {
+	case http.StatusBadRequest:
+		if msg != "" {
+			return fmt.Errorf("bad request: %s", msg)
+		}
+		return fmt.Errorf("bad request")
+	case http.StatusUnauthorized:
+		return fmt.Errorf("authentication failed: check your Sim API key")
+	case http.StatusNotFound:
+		if msg != "" {
+			return fmt.Errorf("not found: %s", msg)
+		}
+		return fmt.Errorf("not found")
+	case http.StatusTooManyRequests:
+		return fmt.Errorf("rate limit exceeded: try again later")
+	default:
+		if status >= 500 {
+			return fmt.Errorf("Sim API server error (HTTP %d): try again later", status)
+		}
+		if msg != "" {
+			return fmt.Errorf("Sim API error (HTTP %d): %s", status, msg)
+		}
+		return fmt.Errorf("Sim API error (HTTP %d)", status)
+	}
+}

--- a/cmd/sim/evm/evm.go
+++ b/cmd/sim/evm/evm.go
@@ -1,0 +1,20 @@
+package evm
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// NewEvmCmd returns the `sim evm` parent command.
+func NewEvmCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "evm",
+		Short: "Query EVM chain data (balances, activity, transactions, etc.)",
+		Long: "Access real-time EVM blockchain data including token balances, activity feeds,\n" +
+			"transaction history, NFT collectibles, token metadata, token holders,\n" +
+			"and DeFi positions.",
+	}
+
+	// Subcommands will be added here as they are implemented.
+
+	return cmd
+}

--- a/cmd/sim/sim.go
+++ b/cmd/sim/sim.go
@@ -1,0 +1,94 @@
+package sim
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/duneanalytics/cli/authconfig"
+	"github.com/duneanalytics/cli/cmd/sim/evm"
+	"github.com/duneanalytics/cli/cmd/sim/svm"
+	"github.com/duneanalytics/cli/cmdutil"
+)
+
+var simAPIKeyFlag string
+
+// NewSimCmd returns the `sim` parent command.
+func NewSimCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "sim",
+		Short: "Query real-time blockchain data via the Sim API",
+		Long: "Access real-time blockchain data including balances, activity, transactions,\n" +
+			"collectibles, token info, token holders, and DeFi positions across EVM and SVM chains.\n\n" +
+			"Authenticate with a Sim API key via --sim-api-key, the DUNE_SIM_API_KEY environment\n" +
+			"variable, or by running `dune sim auth`.",
+		Annotations:       map[string]string{"skipAuth": "true"},
+		PersistentPreRunE: simPreRun,
+	}
+
+	cmd.PersistentFlags().StringVar(
+		&simAPIKeyFlag, "sim-api-key", "",
+		"Sim API key (overrides DUNE_SIM_API_KEY env var)",
+	)
+
+	cmd.AddCommand(evm.NewEvmCmd())
+	cmd.AddCommand(svm.NewSvmCmd())
+
+	return cmd
+}
+
+// simPreRun resolves the Sim API key and stores a SimClient in the command context.
+// Commands annotated with "skipSimAuth": "true" bypass this step.
+func simPreRun(cmd *cobra.Command, _ []string) error {
+	// Allow commands like `sim auth` to skip sim client creation.
+	if cmd.Annotations["skipSimAuth"] == "true" {
+		return nil
+	}
+
+	apiKey := resolveSimAPIKey()
+	if apiKey == "" {
+		return fmt.Errorf(
+			"missing Sim API key: set DUNE_SIM_API_KEY, pass --sim-api-key, or run `dune sim auth`",
+		)
+	}
+
+	client := NewSimClient(apiKey)
+	cmdutil.SetSimClient(cmd, client)
+
+	return nil
+}
+
+// resolveSimAPIKey resolves the Sim API key from (in priority order):
+// 1. --sim-api-key flag
+// 2. DUNE_SIM_API_KEY environment variable
+// 3. sim_api_key from ~/.config/dune/config.yaml
+func resolveSimAPIKey() string {
+	// 1. Flag
+	if simAPIKeyFlag != "" {
+		return strings.TrimSpace(simAPIKeyFlag)
+	}
+
+	// 2. Environment variable
+	if key := os.Getenv("DUNE_SIM_API_KEY"); key != "" {
+		return strings.TrimSpace(key)
+	}
+
+	// 3. Config file
+	cfg, err := authconfig.Load()
+	if err != nil || cfg == nil {
+		return ""
+	}
+	return strings.TrimSpace(cfg.SimAPIKey)
+}
+
+// SimClientFromCmd is a convenience helper that extracts and type-asserts the
+// SimClient from the command context.
+func SimClientFromCmd(cmd *cobra.Command) *SimClient {
+	v := cmdutil.SimClientFromCmd(cmd)
+	if v == nil {
+		return nil
+	}
+	return v.(*SimClient)
+}

--- a/cmd/sim/svm/svm.go
+++ b/cmd/sim/svm/svm.go
@@ -1,0 +1,19 @@
+package svm
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// NewSvmCmd returns the `sim svm` parent command.
+func NewSvmCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "svm",
+		Short: "Query SVM chain data (balances, transactions)",
+		Long: "Access real-time SVM blockchain data including token balances and\n" +
+			"transaction history for Solana and Eclipse chains.",
+	}
+
+	// Subcommands will be added here as they are implemented.
+
+	return cmd
+}

--- a/cmdutil/client.go
+++ b/cmdutil/client.go
@@ -10,6 +10,7 @@ import (
 )
 
 type clientKey struct{}
+type simClientKey struct{}
 type trackerKey struct{}
 type startTimeKey struct{}
 
@@ -25,6 +26,22 @@ func SetClient(cmd *cobra.Command, client dune.DuneClient) {
 // ClientFromCmd extracts the DuneClient stored in the command's context.
 func ClientFromCmd(cmd *cobra.Command) dune.DuneClient {
 	return cmd.Context().Value(clientKey{}).(dune.DuneClient)
+}
+
+// SetSimClient stores a Sim API client in the command's context.
+// The value is stored as any to avoid a circular import with cmd/sim.
+func SetSimClient(cmd *cobra.Command, client any) {
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	cmd.SetContext(context.WithValue(ctx, simClientKey{}, client))
+}
+
+// SimClientFromCmd extracts the Sim API client stored in the command's context.
+// Callers should type-assert the result to *sim.SimClient.
+func SimClientFromCmd(cmd *cobra.Command) any {
+	return cmd.Context().Value(simClientKey{})
 }
 
 // SetTracker stores a Tracker in the command's context.


### PR DESCRIPTION
- Extend authconfig.Config with SimAPIKey field for sim_api_key in config.yaml
- Add SimClient HTTP wrapper (cmd/sim/client.go) with X-Sim-Api-Key auth header
  and structured HTTP error handling (400/401/404/429/500)
- Add SetSimClient/SimClientFromCmd to cmdutil for context-based client injection
- Create sim parent command with PersistentPreRunE that resolves sim API key
  (--sim-api-key flag > DUNE_SIM_API_KEY env > config file)
- Create stub evm/svm parent commands for future subcommands
- Register sim command in cli/root.go init()
- All commands annotated with skipAuth to bypass Dune API key requirement