### PR TITLE
fix(auth): mask API key input during interactive prompt

### DIFF
--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -1,7 +1,6 @@
 package auth
 
 import (
-	"bufio"
 	"fmt"
 	"os"
 	"strings"
@@ -30,19 +29,18 @@ func runAuth(cmd *cobra.Command, _ []string) error {
 	}
 
 	if key == "" {
-		if stdin, ok := cmd.InOrStdin().(*os.File); ok && !term.IsTerminal(int(stdin.Fd())) {
+		stdin, ok := cmd.InOrStdin().(*os.File)
+		if !ok || !term.IsTerminal(int(stdin.Fd())) {
 			return fmt.Errorf("no API key provided; pass --api-key, set DUNE_API_KEY, or run dune auth in an interactive terminal")
 		}
 
-		var (
-			reader = cmd.InOrStdin()
-		)
-
 		fmt.Fprint(cmd.ErrOrStderr(), "Enter your Dune API key: ")
-		scanner := bufio.NewScanner(reader)
-		if scanner.Scan() {
-			key = strings.TrimSpace(scanner.Text())
+		raw, err := term.ReadPassword(int(stdin.Fd()))
+		fmt.Fprintln(cmd.ErrOrStderr()) // newline after hidden input
+		if err != nil {
+			return fmt.Errorf("reading API key: %w", err)
 		}
+		key = strings.TrimSpace(string(raw))
 	}
 
 	if key == "" {

--- a/cmd/auth/auth_test.go
+++ b/cmd/auth/auth_test.go
@@ -62,22 +62,18 @@ func TestAuthWithEnvVar(t *testing.T) {
 	assert.Contains(t, string(data), "env_key")
 }
 
-func TestAuthWithPrompt(t *testing.T) {
-	dir := setup(t)
+func TestAuthNonInteractiveStdinFails(t *testing.T) {
+	setup(t)
 
 	// Unset env var so it doesn't interfere
 	t.Setenv("DUNE_API_KEY", "")
 
 	root := newRoot()
-	var buf bytes.Buffer
-	root.SetOut(&buf)
 	root.SetIn(strings.NewReader("prompt_key\n"))
 	root.SetArgs([]string{"auth"})
-	require.NoError(t, root.Execute())
-
-	data, err := os.ReadFile(filepath.Join(dir, "config.yaml"))
-	require.NoError(t, err)
-	assert.Contains(t, string(data), "prompt_key")
+	err := root.Execute()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no API key provided")
 }
 
 func TestAuthEmptyInput(t *testing.T) {


### PR DESCRIPTION
## Summary

- Use `term.ReadPassword` instead of `bufio.Scanner` to read the API key from stdin during `dune auth`
- The API key is no longer echoed to the terminal, preventing accidental exposure via screen recordings, shoulder surfing, or terminal scrollback history
- The `--api-key` flag and `DUNE_API_KEY` env var paths are unchanged

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./cmd/auth/` passes (4/4 tests)
- [ ] Manual: run `dune auth` interactively and verify the key is hidden while typing
- [ ] Manual: verify `dune auth --api-key <key>` still works
- [ ] Manual: verify `DUNE_API_KEY=<key> dune auth` still works
- [ ] Manual: verify piped/non-interactive stdin still returns a clear error message