### PR TITLE
Update sim evm defi-positions route to /v1/evm/defi/positions

### DIFF
--- a/cmd/sim/evm/defi_positions.go
+++ b/cmd/sim/evm/defi_positions.go
@@ -23,7 +23,6 @@ func NewDefiPositionsCmd() *cobra.Command {
 			"chains and protocols. Each position includes USD valuation and protocol-\n" +
 			"specific metadata. The response also includes aggregation summaries with\n" +
 			"total USD value and per-chain breakdowns.\n\n" +
-			"Note: This endpoint is in beta (served under /beta/evm/defi/positions/*).\n\n" +
 			"Supported position types:\n" +
 			"  - Erc4626: ERC-4626 vault positions (e.g. yield vaults, staking wrappers)\n" +
 			"  - Tokenized: lending protocol positions with receipt tokens (e.g. Aave\n" +
@@ -135,7 +134,7 @@ func runDefiPositions(cmd *cobra.Command, args []string) error {
 		params.Set("chain_ids", v)
 	}
 
-	data, err := client.Get(cmd.Context(), "/beta/evm/defi/positions/"+address, params)
+	data, err := client.Get(cmd.Context(), "/v1/evm/defi/positions/"+address, params)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary
- Point `dune sim evm defi-positions` at the stable `/v1/evm/defi/positions/<address>` route (was `/beta/evm/defi/positions/<address>`).
- Drop the "endpoint is in beta" note from the command's long help, since it's now v1.

## Test plan
- [x] `go build ./...`
- [x] `go test ./cmd/sim/...`
- [x] Live call: `go run ./cmd sim evm defi-positions 0xd8da6bf26964af9d7eed9e03e53415d37aa96045 --chain-ids 1` returns the expected positions table and aggregation summary
- [x] `-o json` output parses as expected (positions + aggregations)