### PR TITLE
fix(cli): allow --performance small for query run and run-sql

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ Manage and execute Dune queries.
 | `query get <query-id>` | Get a saved query's details and SQL |
 | `query update <query-id> [--name] [--sql] [--description] [--private] [--tags]` | Update an existing query |
 | `query archive <query-id>` | Archive a saved query |
-| `query run <query-id> [--param key=value] [--performance medium\|large] [--limit] [--timeout] [--no-wait]` | Execute a saved query and display results |
-| `query run-sql --sql <sql> [--param key=value] [--performance medium\|large] [--limit] [--timeout] [--no-wait]` | Execute raw SQL directly |
+| `query run <query-id> [--param key=value] [--performance small\|medium\|large] [--limit] [--timeout] [--no-wait]` | Execute a saved query and display results |
+| `query run-sql --sql <sql> [--param key=value] [--performance small\|medium\|large] [--limit] [--timeout] [--no-wait]` | Execute raw SQL directly |
 
 ### `dune execution`
 

--- a/cmd/query/helpers.go
+++ b/cmd/query/helpers.go
@@ -22,8 +22,11 @@ func parseQueryID(arg string) (int, error) {
 
 func parsePerformance(cmd *cobra.Command) (string, error) {
 	performance, _ := cmd.Flags().GetString("performance")
-	if performance != "medium" && performance != "large" {
-		return "", fmt.Errorf("invalid performance tier %q: must be \"medium\" or \"large\"", performance)
+	if performance != "small" && performance != "medium" && performance != "large" {
+		return "", fmt.Errorf(
+			"invalid performance tier %q: must be \"small\", \"medium\" or \"large\"",
+			performance,
+		)
 	}
 	return performance, nil
 }

--- a/cmd/query/run.go
+++ b/cmd/query/run.go
@@ -35,7 +35,7 @@ func newRunCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringArray("param", nil, "typed query parameter in key=value format (repeatable); supported types: text, number (stringified, e.g. '30'), datetime (YYYY-MM-DD HH:mm:ss), enum")
-	cmd.Flags().String("performance", "medium", `engine size for the execution: "medium" (default) or "large"; credits are consumed based on actual compute resources used`)
+	cmd.Flags().String("performance", "medium", `engine size for the execution: "small", "medium" (default) or "large"; credits are consumed based on actual compute resources used`)
 	cmd.Flags().Int("limit", 0, "maximum number of result rows to return (0 = all available rows)")
 	cmd.Flags().Bool("no-wait", false, "submit the execution and exit immediately, printing only the execution ID and state")
 	cmd.Flags().Int("timeout", 300, "maximum seconds to wait for the execution to complete before timing out")

--- a/cmd/query/run_sql.go
+++ b/cmd/query/run_sql.go
@@ -36,7 +36,7 @@ func newRunSQLCmd() *cobra.Command {
 	cmd.Flags().String("sql", "", "the SQL query text in DuneSQL dialect (required)")
 	_ = cmd.MarkFlagRequired("sql")
 	cmd.Flags().StringArray("param", nil, "typed query parameter in key=value format (repeatable); supported types: text, number (stringified, e.g. '30'), datetime (YYYY-MM-DD HH:mm:ss), enum")
-	cmd.Flags().String("performance", "medium", `engine size for the execution: "medium" (default) or "large"; credits are consumed based on actual compute resources used`)
+	cmd.Flags().String("performance", "medium", `engine size for the execution: "small", "medium" (default) or "large"; credits are consumed based on actual compute resources used`)
 	cmd.Flags().Int("limit", 0, "maximum number of result rows to return (0 = all available rows)")
 	cmd.Flags().Bool("no-wait", false, "submit the execution and exit immediately, printing only the execution ID and state")
 	cmd.Flags().Int("timeout", 300, "maximum seconds to wait for the execution to complete before timing out")


### PR DESCRIPTION
- Extend parsePerformance to accept small alongside medium and large (matches public API / Dune API client).
- Update dune query run and dune query run-sql flag help and README so docs match the allowed values.
- No change to default performance (still medium).