### PR TITLE
Allow small, medium and large engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ Manage and execute Dune queries.
 | `query get <query-id>` | Get a saved query's details and SQL |
 | `query update <query-id> [--name] [--sql] [--description] [--private] [--tags]` | Update an existing query |
 | `query archive <query-id>` | Archive a saved query |
-| `query run <query-id> [--param key=value] [--performance free\|small\|medium\|large] [--limit] [--timeout] [--no-wait]` | Execute a saved query and display results |
-| `query run-sql --sql <sql> [--param key=value] [--performance free\|small\|medium\|large] [--limit] [--timeout] [--no-wait]` | Execute raw SQL directly |
+| `query run <query-id> [--param key=value] [--performance small\|medium\|large] [--limit] [--timeout] [--no-wait]` | Execute a saved query and display results |
+| `query run-sql --sql <sql> [--param key=value] [--performance small\|medium\|large] [--limit] [--timeout] [--no-wait]` | Execute raw SQL directly |
 
 ### `dune execution`
 

--- a/cmd/query/helpers.go
+++ b/cmd/query/helpers.go
@@ -23,11 +23,13 @@ func parseQueryID(arg string) (int, error) {
 func parsePerformance(cmd *cobra.Command) (string, error) {
 	performance, _ := cmd.Flags().GetString("performance")
 	switch performance {
-	case "", "free", "medium", "large":
+	// "free" is accepted for backwards compatibility but not advertised. New callers should
+	// use "small".
+	case "", "small", "medium", "large", "free":
 		return performance, nil
 	default:
 		return "", fmt.Errorf(
-			"invalid performance tier %q: must be \"free\", \"medium\" or \"large\"",
+			"invalid performance tier %q: must be \"small\", \"medium\" or \"large\"",
 			performance,
 		)
 	}

--- a/cmd/query/run.go
+++ b/cmd/query/run.go
@@ -35,7 +35,7 @@ func newRunCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringArray("param", nil, "typed query parameter in key=value format (repeatable); supported types: text, number (stringified, e.g. '30'), datetime (YYYY-MM-DD HH:mm:ss), enum")
-	cmd.Flags().String("performance", "", `engine tier override: "free", "medium", or "large"; omit to let the API auto-select based on your plan`)
+	cmd.Flags().String("performance", "", `engine tier override: "small", "medium", or "large"; omit to let the API auto-select based on your plan`)
 	cmd.Flags().Int("limit", 0, "maximum number of result rows to return (0 = all available rows)")
 	cmd.Flags().Bool("no-wait", false, "submit the execution and exit immediately, printing only the execution ID and state")
 	cmd.Flags().Int("timeout", 300, "maximum seconds to wait for the execution to complete before timing out")

--- a/cmd/query/run_sql.go
+++ b/cmd/query/run_sql.go
@@ -37,7 +37,7 @@ func newRunSQLCmd() *cobra.Command {
 	cmd.Flags().String("sql", "", "the SQL query text in DuneSQL dialect (required)")
 	_ = cmd.MarkFlagRequired("sql")
 	cmd.Flags().StringArray("param", nil, "typed query parameter in key=value format (repeatable); supported types: text, number (stringified, e.g. '30'), datetime (YYYY-MM-DD HH:mm:ss), enum")
-	cmd.Flags().String("performance", "", `engine tier override: "free", "medium", or "large"; omit to let the API auto-select based on your plan`)
+	cmd.Flags().String("performance", "", `engine tier override: "small", "medium", or "large"; omit to let the API auto-select based on your plan`)
 	cmd.Flags().Int("limit", 0, "maximum number of result rows to return (0 = all available rows)")
 	cmd.Flags().Bool("no-wait", false, "submit the execution and exit immediately, printing only the execution ID and state")
 	cmd.Flags().Int("timeout", 300, "maximum seconds to wait for the execution to complete before timing out")

--- a/cmd/query/run_sql_test.go
+++ b/cmd/query/run_sql_test.go
@@ -133,7 +133,7 @@ func TestRunSQLWithPerformance(t *testing.T) {
 	assert.Equal(t, "large", captured.Performance)
 }
 
-func TestRunSQLWithPerformanceFree(t *testing.T) {
+func TestRunSQLWithPerformanceSmall(t *testing.T) {
 	var captured models.ExecuteSQLRequest
 	mock := &mockClient{
 		runSQLFn: func(req models.ExecuteSQLRequest) (dune.Execution, error) {
@@ -148,10 +148,10 @@ func TestRunSQLWithPerformanceFree(t *testing.T) {
 	}
 
 	root, _ := newTestRoot(mock)
-	root.SetArgs([]string{"query", "run-sql", "--sql", "SELECT 1", "--performance", "free"})
+	root.SetArgs([]string{"query", "run-sql", "--sql", "SELECT 1", "--performance", "small"})
 	require.NoError(t, root.Execute())
 
-	assert.Equal(t, "free", captured.Performance)
+	assert.Equal(t, "small", captured.Performance)
 }
 
 func TestRunSQLExecutionFailed(t *testing.T) {
@@ -253,6 +253,29 @@ func TestRunSQLInvalidPerformance(t *testing.T) {
 	err := root.Execute()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid performance tier")
+}
+
+// TestRunSQLAcceptsLegacyFreePerformance pins backwards compatibility: "free" is no longer
+// advertised but must still be accepted and forwarded so existing scripts keep working.
+func TestRunSQLAcceptsLegacyFreePerformance(t *testing.T) {
+	var captured models.ExecuteSQLRequest
+	mock := &mockClient{
+		runSQLFn: func(req models.ExecuteSQLRequest) (dune.Execution, error) {
+			captured = req
+			return &mockExecution{
+				id: "01ABC",
+				waitGetResultsFn: func(_ time.Duration, _ int) (*models.ResultsResponse, error) {
+					return testResultsResponse, nil
+				},
+			}, nil
+		},
+	}
+
+	root, _ := newTestRoot(mock)
+	root.SetArgs([]string{"query", "run-sql", "--sql", "SELECT 1", "--performance", "free"})
+	require.NoError(t, root.Execute())
+
+	assert.Equal(t, "free", captured.Performance)
 }
 
 func TestRunSQLInvalidParam(t *testing.T) {

--- a/cmd/query/run_test.go
+++ b/cmd/query/run_test.go
@@ -272,3 +272,26 @@ func TestRunInvalidPerformance(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid performance tier")
 }
+
+// TestRunAcceptsLegacyFreePerformance pins backwards compatibility: "free" is no longer
+// advertised but must still be accepted and forwarded so existing scripts keep working.
+func TestRunAcceptsLegacyFreePerformance(t *testing.T) {
+	var captured models.ExecuteRequest
+	mock := &mockClient{
+		runQueryFn: func(req models.ExecuteRequest) (dune.Execution, error) {
+			captured = req
+			return &mockExecution{
+				id: "01ABC",
+				waitGetResultsFn: func(_ time.Duration, _ int) (*models.ResultsResponse, error) {
+					return testResultsResponse, nil
+				},
+			}, nil
+		},
+	}
+
+	root, _ := newTestRoot(mock)
+	root.SetArgs([]string{"query", "run", "4125432", "--performance", "free"})
+	require.NoError(t, root.Execute())
+
+	assert.Equal(t, "free", captured.Performance)
+}


### PR DESCRIPTION
Updates dune query run and dune query run-sql to advertise --performance tiers as small|medium|large (including README and flag help text), replacing the previously documented free tier.